### PR TITLE
Include the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.9.0"
 description = "SDK Client for Ory"
 documentation = "https://www.ory.sh/docs/sdk"
 homepage = "https://www.ory.sh"
+repository = "https://github.com/ory/client-rust"
 license = "Apache-2.0"
 authors = ["OpenAPI Generator team and contributors"]
 edition = "2018"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.