### PR TITLE
Wasm support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ serde_with = { version = "^3.8", default-features = false, features = ["base64",
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-uuid = { version = "^1.8", features = ["serde", "v4"] }
+uuid = { version = "^1.8", features = ["serde", "v4", "js"] }
 reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart"] }


### PR DESCRIPTION
The client didn't build for WASM targets.
I added the 'js' feature flag to the uuid crate, in order to enable WASM. This seems to be the only dependency that needed any change. It now builds for WASM.
